### PR TITLE
Add minimal Flask login demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # Operations
+
+This repository contains a minimal Flask application demonstrating role-based login for a BPO system.
+
+## Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install Flask
+   ```
+
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+
+3. Navigate to `http://localhost:5000` and log in with one of the demo accounts:
+   - Agent: `agent1` / `pass`
+   - Admin: `admin1` / `pass`
+
+This is a simple starting point and does not implement the full specification.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,48 @@
+from flask import Flask, render_template, request, redirect, session, url_for
+
+app = Flask(__name__)
+app.secret_key = 'change-this-secret'
+
+# Dummy users for demo purposes
+USERS = {
+    'agent1': {'password': 'pass', 'role': 'agent'},
+    'admin1': {'password': 'pass', 'role': 'admin'}
+}
+
+@app.route('/', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = USERS.get(username)
+        if user and user['password'] == password:
+            session['user'] = {'username': username, 'role': user['role']}
+            if user['role'] == 'agent':
+                return redirect(url_for('agent_dashboard'))
+            else:
+                return redirect(url_for('admin_dashboard'))
+        else:
+            return render_template('login.html', error='Invalid credentials')
+    return render_template('login.html')
+
+@app.route('/agent')
+def agent_dashboard():
+    user = session.get('user')
+    if not user or user.get('role') != 'agent':
+        return redirect(url_for('login'))
+    return render_template('agent_dashboard.html', user=user)
+
+@app.route('/admin')
+def admin_dashboard():
+    user = session.get('user')
+    if not user or user.get('role') != 'admin':
+        return redirect(url_for('login'))
+    return render_template('admin_dashboard.html', user=user)
+
+@app.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('login'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Admin Dashboard</title>
+</head>
+<body>
+    <h1>Admin Dashboard</h1>
+    <p>Welcome, {{ user.username }} ({{ user.role }})</p>
+    <a href="/logout">Logout</a>
+</body>
+</html>

--- a/templates/agent_dashboard.html
+++ b/templates/agent_dashboard.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Agent Dashboard</title>
+</head>
+<body>
+    <h1>Agent Dashboard</h1>
+    <p>Welcome, {{ user.username }} (Agent)</p>
+    <a href="/logout">Logout</a>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+    <form method="post">
+        <label for="username">Username:</label><br>
+        <input type="text" id="username" name="username" required><br>
+        <label for="password">Password:</label><br>
+        <input type="password" id="password" name="password" required><br>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create minimal Flask app demonstrating role-based login
- add simple HTML templates for login and dashboards
- document setup and usage in README

## Testing
- `python3 -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6859b5439dd883268a11efff2f41b993